### PR TITLE
SNAK-198: GET /api/v1/snacks/?active=

### DIFF
--- a/src/snack/controller.js
+++ b/src/snack/controller.js
@@ -63,13 +63,13 @@ export const addSnackBatches = async(req, res) => {
 
 export const getSnacks = async(req, res) => {
     try {
-        let { active } = req.query
-        let is_active = parseQueryParams(active)
+        const { active } = req.query
+        const is_active = active !== 'false'
 
         const snacks =  await Snacks.findAll({
-            where: { is_active : is_active }
+            where: { is_active }
         })
-        const response = {'snacks': snacks}
+        const response = { snacks }
         
         return res.status(200).send(response)
     } catch (err) {
@@ -77,9 +77,3 @@ export const getSnacks = async(req, res) => {
     }
 }
 
-function parseQueryParams(active) {
-    if( active === undefined || active != 'false') {
-        return true
-    }
-    return false 
-}


### PR DESCRIPTION
Description of PR that completes the issue here

## Ticket Info
- Ticket Number: SNAK-198
- Ticket Link: https://team-1600642168705.atlassian.net/browse/SNAK-198

## Changes
- Description of changes: GET /api/v1/snacks/?active=true only returns items that are is_active = true, default true

## Screenshots 
- Screenshots from Postman displaying both request and response: 
1. active = true => is_active = true
![image](https://user-images.githubusercontent.com/40282705/108634917-fc97ef80-7430-11eb-9a5e-d48628eaa92f.png)
2. active = false => is_active = false
![image](https://user-images.githubusercontent.com/40282705/108634920-03befd80-7431-11eb-9c2a-cc22fa1b63ae.png)
3. active = blah => is_active = true
![image](https://user-images.githubusercontent.com/40282705/108634911-f30e8780-7430-11eb-901b-cbe1e756ffe0.png)
4. empty => is_active = true
![image](https://user-images.githubusercontent.com/40282705/108634924-09b4de80-7431-11eb-8ad8-10d02632b222.png)

## Checklist
*If you don't meet all checklist items, please do not post a PR. If you think you don't have to check all items, please describe a reason below!*

- [x] yarn lint success?
- [x] yarn run start success?
- [x] test locally through postman?
- [x] update any changes to Jira ticket and Design Doc?
- [x] follow github commit convention? https://www.conventionalcommits.org/en/v1.0.0/




