### PR TITLE
SNAK-222: GET /api/v1/snacks/ should return snacks sorted by snack_type_id

### DIFF
--- a/src/snack/controller.js
+++ b/src/snack/controller.js
@@ -10,9 +10,9 @@ const SnackBatches = db.snackBatches
 export const addSnack = async(req, res) => {
     try {
         const snack = req.body
+        if (snack.quantity < 0) throw Error(400)
         const result = await Snacks.create(snack)
         let quantity = 0
-        if (snack.quantity < 0) throw Error(400)
         if (snack.quantity > 0) {
             quantity = snack.quantity
             const snackBatch = {


### PR DESCRIPTION
Description of PR that completes the issue here

## Ticket Info
- Ticket Number: 222
- Ticket Link: https://team-1600642168705.atlassian.net/browse/SNAK-222

## Changes
- Description of changes: GET snacks now return sorted snacks by snack_type_id. And did some refactoring with snack APIs

## Screenshots 
- Screenshots from Postman displaying both request and response: 
![222](https://user-images.githubusercontent.com/38146012/109268188-8e03ba80-77bf-11eb-8fd2-11e268a9dfaf.PNG)


## Checklist
*If you don't meet all checklist items, please do not post a PR. If you think you don't have to check all items, please describe a reason below!*

- [x] yarn lint success?
- [x] yarn run start success?
- [x] test locally through postman?
- [x] update any changes to Jira ticket and Design Doc?
- [x] follow github commit convention? https://www.conventionalcommits.org/en/v1.0.0/




