### PR TITLE
fix: add return result in transactions

### DIFF
--- a/src/transaction/controller.js
+++ b/src/transaction/controller.js
@@ -48,7 +48,8 @@ export const addTransaction = async (req, res) => {
     transaction.payment_id = null
     transaction.snack_name = snack.snack_name
 
-    await Transactions.create(transaction)
+    const result = await Transactions.create(transaction)
+    return res.status(201).send(result)
   } catch (err) {
     const code = Number(err.message)
     if (err.name) {


### PR DESCRIPTION
During applying eslint, return result was deleted in transactions.
It was reverted in this PR. Tested in Postman
![image](https://user-images.githubusercontent.com/38146012/110205403-947fdb00-7e2c-11eb-8033-f1b732d8a7b9.png)
